### PR TITLE
ci: add cascading notification support

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -27,18 +27,43 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          path: meta_project_cli
           # Use PAT to trigger downstream workflows; fallback to GITHUB_TOKEN
           token: ${{ secrets.PARENT_REPO_PAT || github.token }}
+
+      - name: Clone dependencies
+        run: |
+          git clone --depth 1 https://github.com/harmony-labs/meta_plugin_protocol.git
+          git clone --depth 1 https://github.com/harmony-labs/meta_cli.git
+          git clone --depth 1 https://github.com/harmony-labs/meta_core.git
+          git clone --depth 1 https://github.com/harmony-labs/meta_git_lib.git
+          git clone --depth 1 https://github.com/harmony-labs/loop_lib.git
+
+      - name: Create workspace Cargo.toml
+        run: |
+          cat > Cargo.toml << 'EOF'
+          [workspace]
+          members = ["meta_project_cli", "meta_plugin_protocol", "meta_cli", "meta_core", "meta_git_lib", "loop_lib"]
+          resolver = "2"
+
+          [workspace.package]
+          version = "0.1.0"
+          edition = "2021"
+          license = "MIT"
+          repository = "https://github.com/harmony-labs/meta"
+          EOF
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
       - name: Run cargo fmt
+        working-directory: meta_project_cli
         run: cargo fmt --all
 
       - name: Check for changes
         id: changes
+        working-directory: meta_project_cli
         run: |
           if git diff --quiet; then
             echo "formatted=false" >> $GITHUB_OUTPUT
@@ -48,6 +73,7 @@ jobs:
 
       - name: Commit and push
         if: steps.changes.outputs.formatted == 'true'
+        working-directory: meta_project_cli
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  repository_dispatch:
+    types: [dependency-updated]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,21 @@ jobs:
           git clone --depth 1 https://github.com/harmony-labs/meta_git_lib.git
           git clone --depth 1 https://github.com/harmony-labs/loop_lib.git
 
+      - name: Create workspace Cargo.toml
+        shell: bash
+        run: |
+          cat > Cargo.toml << 'EOF'
+          [workspace]
+          members = ["meta_project_cli", "meta_plugin_protocol", "meta_cli", "meta_core", "meta_git_lib", "loop_lib"]
+          resolver = "2"
+
+          [workspace.package]
+          version = "0.1.0"
+          edition = "2021"
+          license = "MIT"
+          repository = "https://github.com/harmony-labs/meta"
+          EOF
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -63,6 +78,20 @@ jobs:
           git clone --depth 1 https://github.com/harmony-labs/meta_git_lib.git
           git clone --depth 1 https://github.com/harmony-labs/loop_lib.git
 
+      - name: Create workspace Cargo.toml
+        run: |
+          cat > Cargo.toml << 'EOF'
+          [workspace]
+          members = ["meta_project_cli", "meta_plugin_protocol", "meta_cli", "meta_core", "meta_git_lib", "loop_lib"]
+          resolver = "2"
+
+          [workspace.package]
+          version = "0.1.0"
+          edition = "2021"
+          license = "MIT"
+          repository = "https://github.com/harmony-labs/meta"
+          EOF
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -83,6 +112,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          path: meta_project_cli
+
+      - name: Clone dependencies
+        run: |
+          git clone --depth 1 https://github.com/harmony-labs/meta_plugin_protocol.git
+          git clone --depth 1 https://github.com/harmony-labs/meta_cli.git
+          git clone --depth 1 https://github.com/harmony-labs/meta_core.git
+          git clone --depth 1 https://github.com/harmony-labs/meta_git_lib.git
+          git clone --depth 1 https://github.com/harmony-labs/loop_lib.git
+
+      - name: Create workspace Cargo.toml
+        run: |
+          cat > Cargo.toml << 'EOF'
+          [workspace]
+          members = ["meta_project_cli", "meta_plugin_protocol", "meta_cli", "meta_core", "meta_git_lib", "loop_lib"]
+          resolver = "2"
+
+          [workspace.package]
+          version = "0.1.0"
+          edition = "2021"
+          license = "MIT"
+          repository = "https://github.com/harmony-labs/meta"
+          EOF
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -90,4 +143,5 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
+        working-directory: meta_project_cli
         run: cargo fmt --all -- --check

--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -1,0 +1,73 @@
+name: Notify Parent Repo
+
+on:
+  push:
+    branches: [main]
+  repository_dispatch:
+    types: [dependency-updated]
+
+jobs:
+  wait-for-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for CI
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: 'Test (ubuntu-latest)'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
+  notify-parent:
+    needs: wait-for-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine source
+        id: source
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "repo=${{ github.event.client_payload.repo }}" >> $GITHUB_OUTPUT
+            echo "repo_name=${{ github.event.client_payload.repo_name }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ github.event.client_payload.sha }}" >> $GITHUB_OUTPUT
+            echo "short_sha=${{ github.event.client_payload.short_sha }}" >> $GITHUB_OUTPUT
+            echo "message=${{ github.event.client_payload.message }}" >> $GITHUB_OUTPUT
+            echo "type=${{ github.event.client_payload.type }}" >> $GITHUB_OUTPUT
+            echo "actor=${{ github.event.client_payload.actor }}" >> $GITHUB_OUTPUT
+          else
+            MSG=$(git log -1 --pretty=%s)
+            echo "message=$MSG" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
+            echo "repo_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+            echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+            echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+            if [[ "$MSG" =~ ^feat ]]; then echo "type=feat" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^fix ]]; then echo "type=fix" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^chore ]]; then echo "type=chore" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^docs ]]; then echo "type=docs" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^test ]]; then echo "type=test" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^refactor ]]; then echo "type=refactor" >> $GITHUB_OUTPUT
+            else echo "type=other" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Notify parent repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PARENT_REPO_PAT }}
+          repository: harmony-labs/meta
+          event-type: child-repo-updated
+          client-payload: |
+            {
+              "repo": "${{ steps.source.outputs.repo }}",
+              "repo_name": "${{ steps.source.outputs.repo_name }}",
+              "sha": "${{ steps.source.outputs.sha }}",
+              "short_sha": "${{ steps.source.outputs.short_sha }}",
+              "message": "${{ steps.source.outputs.message }}",
+              "type": "${{ steps.source.outputs.type }}",
+              "actor": "${{ steps.source.outputs.actor }}"
+            }

--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for CI
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.5.0
         with:
           ref: ${{ github.sha }}
           check-name: 'Test (ubuntu-latest)'
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Determine source
         id: source
@@ -43,14 +41,15 @@ jobs:
             echo "message=$MSG" >> $GITHUB_OUTPUT
             echo "repo=${{ github.repository }}" >> $GITHUB_OUTPUT
             echo "repo_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
+            echo "actor=${{ github.actor }}" >> $GITHUB_OUTPUT
             echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
             echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-            if [[ "$MSG" =~ ^feat ]]; then echo "type=feat" >> $GITHUB_OUTPUT
-            elif [[ "$MSG" =~ ^fix ]]; then echo "type=fix" >> $GITHUB_OUTPUT
-            elif [[ "$MSG" =~ ^chore ]]; then echo "type=chore" >> $GITHUB_OUTPUT
-            elif [[ "$MSG" =~ ^docs ]]; then echo "type=docs" >> $GITHUB_OUTPUT
-            elif [[ "$MSG" =~ ^test ]]; then echo "type=test" >> $GITHUB_OUTPUT
-            elif [[ "$MSG" =~ ^refactor ]]; then echo "type=refactor" >> $GITHUB_OUTPUT
+            if [[ "$MSG" =~ ^feat[:(] ]]; then echo "type=feat" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^fix[:(] ]]; then echo "type=fix" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^chore[:(] ]]; then echo "type=chore" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^docs[:(] ]]; then echo "type=docs" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^test[:(] ]]; then echo "type=test" >> $GITHUB_OUTPUT
+            elif [[ "$MSG" =~ ^refactor[:(] ]]; then echo "type=refactor" >> $GITHUB_OUTPUT
             else echo "type=other" >> $GITHUB_OUTPUT
             fi
           fi
@@ -61,13 +60,13 @@ jobs:
           token: ${{ secrets.PARENT_REPO_PAT }}
           repository: harmony-labs/meta
           event-type: child-repo-updated
-          client-payload: |
+          client-payload: >-
             {
-              "repo": "${{ steps.source.outputs.repo }}",
-              "repo_name": "${{ steps.source.outputs.repo_name }}",
-              "sha": "${{ steps.source.outputs.sha }}",
-              "short_sha": "${{ steps.source.outputs.short_sha }}",
-              "message": "${{ steps.source.outputs.message }}",
-              "type": "${{ steps.source.outputs.type }}",
-              "actor": "${{ steps.source.outputs.actor }}"
+              "repo": ${{ toJSON(steps.source.outputs.repo) }},
+              "repo_name": ${{ toJSON(steps.source.outputs.repo_name) }},
+              "sha": ${{ toJSON(steps.source.outputs.sha) }},
+              "short_sha": ${{ toJSON(steps.source.outputs.short_sha) }},
+              "message": ${{ toJSON(steps.source.outputs.message) }},
+              "type": ${{ toJSON(steps.source.outputs.type) }},
+              "actor": ${{ toJSON(steps.source.outputs.actor) }}
             }


### PR DESCRIPTION
## Summary
- Adds `repository_dispatch` trigger to CI so upstream dependency updates run the test suite
- Adds `notify-parent.yml` to notify the meta parent repo after CI passes (on push or upstream cascade)

## Test plan
- [ ] Verify CI still runs on push/PR
- [ ] After merge, verify notify-parent dispatches to meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)