### PR TITLE
feat(project-list): add absolute root field to --json output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,7 +704,9 @@ mod tests {
         match result {
             CommandResult::Message(msg) => {
                 let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
-                let cwd = parsed["cwd"].as_str().expect("cwd field should be a string");
+                let cwd = parsed["cwd"]
+                    .as_str()
+                    .expect("cwd field should be a string");
                 let root = parsed["root"]
                     .as_str()
                     .expect("root field should be a string");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub struct ProjectTreeNode {
 pub struct ProjectListOutput {
     pub path: String,
     pub repo: String,
+    pub root: String,
     pub cwd: String,
     pub projects: Vec<ProjectTreeNode>,
 }
@@ -225,9 +226,15 @@ fn handle_project_list(cwd: &Path, options: &ExecuteOptions) -> CommandResult {
         .to_string();
 
     if options.json_output {
+        let abs_root = start_dir
+            .canonicalize()
+            .unwrap_or_else(|_| start_dir.clone())
+            .to_string_lossy()
+            .to_string();
         let output = ProjectListOutput {
             path: ".".to_string(),
             repo: root_repo,
+            root: abs_root,
             cwd: abs_cwd,
             projects: project_nodes,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@ fn handle_project_list(cwd: &Path, options: &ExecuteOptions) -> CommandResult {
         };
         let abs_root = root_dir
             .canonicalize()
-            .unwrap_or_else(|_| root_dir)
+            .unwrap_or(root_dir)
             .to_string_lossy()
             .to_string();
         let output = ProjectListOutput {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,9 +226,24 @@ fn handle_project_list(cwd: &Path, options: &ExecuteOptions) -> CommandResult {
         .to_string();
 
     if options.json_output {
-        let abs_root = start_dir
+        // `root` = the .meta config directory relevant to this invocation:
+        //   - recursive: the outermost workspace root (same as start_dir)
+        //   - non-recursive: the nearest ancestor .meta config dir
+        // In both cases start_dir is wrong for non-recursive (it equals cwd).
+        let root_dir = if options.recursive {
+            start_dir.clone()
+        } else {
+            match config::find_meta_config(cwd, None) {
+                Some((config_path, _)) => config_path
+                    .parent()
+                    .unwrap_or(cwd)
+                    .to_path_buf(),
+                None => start_dir.clone(),
+            }
+        };
+        let abs_root = root_dir
             .canonicalize()
-            .unwrap_or_else(|_| start_dir.clone())
+            .unwrap_or_else(|_| root_dir)
             .to_string_lossy()
             .to_string();
         let output = ProjectListOutput {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,6 +658,65 @@ mod tests {
                     std::path::Path::new(cwd).is_absolute(),
                     "cwd should be absolute, got: {cwd}"
                 );
+                // root field should be present and be an absolute path
+                let root = parsed["root"]
+                    .as_str()
+                    .expect("root field should be a string");
+                assert!(
+                    std::path::Path::new(root).is_absolute(),
+                    "root should be absolute, got: {root}"
+                );
+            }
+            _ => panic!("Expected Message result"),
+        }
+    }
+
+    #[test]
+    fn test_project_list_json_root_differs_from_cwd_in_nested_recursive() {
+        // Regression: when invoked from a child directory with --recursive,
+        // `root` must point to the outermost workspace root, NOT to cwd.
+        let temp_dir = TempDir::new().unwrap();
+        let child = temp_dir.path().join("child");
+        std::fs::create_dir_all(&child).unwrap();
+
+        // Root .meta
+        std::fs::write(
+            temp_dir.path().join(".meta"),
+            r#"{"projects": {"child": {"repo": "git@github.com:org/child.git", "meta": true}}}"#,
+        )
+        .unwrap();
+
+        // Child .meta
+        std::fs::write(
+            child.join(".meta"),
+            r#"{"projects": {"repo1": "git@github.com:org/repo1.git"}}"#,
+        )
+        .unwrap();
+
+        let options = ExecuteOptions {
+            recursive: true,
+            json_output: true,
+            ..Default::default()
+        };
+        // Run from child (nested) directory
+        let result = execute_command("project list", &[], &options, &[], &child);
+
+        match result {
+            CommandResult::Message(msg) => {
+                let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+                let cwd = parsed["cwd"].as_str().expect("cwd field should be a string");
+                let root = parsed["root"]
+                    .as_str()
+                    .expect("root field should be a string");
+                assert!(
+                    std::path::Path::new(root).is_absolute(),
+                    "root should be absolute, got: {root}"
+                );
+                // root must be the outermost workspace root, which is the parent of child
+                assert_ne!(
+                    root, cwd,
+                    "root should differ from cwd when invoked from a nested meta workspace"
+                );
             }
             _ => panic!("Expected Message result"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,10 +234,7 @@ fn handle_project_list(cwd: &Path, options: &ExecuteOptions) -> CommandResult {
             start_dir.clone()
         } else {
             match config::find_meta_config(cwd, None) {
-                Some((config_path, _)) => config_path
-                    .parent()
-                    .unwrap_or(cwd)
-                    .to_path_buf(),
+                Some((config_path, _)) => config_path.parent().unwrap_or(cwd).to_path_buf(),
                 None => start_dir.clone(),
             }
         };


### PR DESCRIPTION
## Summary

- Adds a `root` field to the `ProjectListOutput` struct — the absolute filesystem path of the meta workspace root
- `root` is distinct from `cwd`: `cwd` is where the user typed the command; `root` is where meta found the top-level workspace config (via `find_root_meta_dir`)

## Why

Consumers like gitkb need to resolve project paths (which are relative to the workspace root) to absolute filesystem paths. Without `root`, there was no reliable way to do this — previous attempts used `.meta` file scanning or git topology heuristics, both of which broke in common setups.

## Example output

```json
{
  "path": ".",
  "root": "/Users/matt/development/harmony",
  "cwd": "/Users/matt/development/harmony/open-source/gitkb",
  "projects": [...]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project list JSON now includes an absolute root path for each project, improving clarity of directory layout and file locations when exporting or viewing projects.

* **Tests**
  * Added/extended tests to verify the root field is present, absolute, and correct across nested, recursive, and non-recursive project listing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->