### PR TITLE
chore: restore notify-parent workflow (simplified)

### DIFF
--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -1,0 +1,26 @@
+name: Notify Parent Repo
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify parent repo
+        # PARENT_REPO_PAT requires `repo` scope (or fine-grained `contents:write`)
+        # on harmony-labs/meta. Configure in Settings → Secrets → Actions.
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
+        with:
+          token: ${{ secrets.PARENT_REPO_PAT }}
+          repository: harmony-labs/meta
+          event-type: child-repo-updated
+          client-payload: >-
+            {
+              "repo_name": ${{ toJSON(github.event.repository.name) }},
+              "sha": ${{ toJSON(github.sha) }},
+              "actor": ${{ toJSON(github.actor) }}
+            }


### PR DESCRIPTION
Re-adds `notify-parent.yml` to trigger parent meta repo's release-please when this child repo merges to main. 

Simplified: no commit message parsing, just dispatches repo name and SHA. Companion to harmony-labs/meta#62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automation to notify the parent repository whenever changes are pushed to the main branch. The notification includes repository and commit metadata so the parent can track child-repo updates and react to new pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->