### PR TITLE
fix: document project command help

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -33,11 +33,11 @@ jobs:
 
       - name: Clone dependencies
         run: |
-          git clone --depth 1 https://github.com/harmony-labs/meta_plugin_protocol.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_cli.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_core.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_git_lib.git
-          git clone --depth 1 https://github.com/harmony-labs/loop_lib.git
+          git clone --depth 1 https://github.com/gitkb/meta_plugin_protocol.git
+          git clone --depth 1 https://github.com/gitkb/meta_cli.git
+          git clone --depth 1 https://github.com/gitkb/meta_core.git
+          git clone --depth 1 https://github.com/gitkb/meta_git_lib.git
+          git clone --depth 1 https://github.com/gitkb/loop_lib.git
 
       - name: Create workspace Cargo.toml
         run: |
@@ -50,7 +50,7 @@ jobs:
           version = "0.1.0"
           edition = "2021"
           license = "MIT"
-          repository = "https://github.com/harmony-labs/meta"
+          repository = "https://github.com/gitkb/meta"
           EOF
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Clone dependencies
         shell: bash
         run: |
-          git clone --depth 1 https://github.com/harmony-labs/meta_plugin_protocol.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_cli.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_core.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_git_lib.git
-          git clone --depth 1 https://github.com/harmony-labs/loop_lib.git
+          git clone --depth 1 https://github.com/gitkb/meta_plugin_protocol.git
+          git clone --depth 1 https://github.com/gitkb/meta_cli.git
+          git clone --depth 1 https://github.com/gitkb/meta_core.git
+          git clone --depth 1 https://github.com/gitkb/meta_git_lib.git
+          git clone --depth 1 https://github.com/gitkb/loop_lib.git
 
       - name: Create workspace Cargo.toml
         shell: bash
@@ -46,7 +46,7 @@ jobs:
           version = "0.1.0"
           edition = "2021"
           license = "MIT"
-          repository = "https://github.com/harmony-labs/meta"
+          repository = "https://github.com/gitkb/meta"
           EOF
 
       - name: Install Rust toolchain
@@ -72,11 +72,11 @@ jobs:
 
       - name: Clone dependencies
         run: |
-          git clone --depth 1 https://github.com/harmony-labs/meta_plugin_protocol.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_cli.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_core.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_git_lib.git
-          git clone --depth 1 https://github.com/harmony-labs/loop_lib.git
+          git clone --depth 1 https://github.com/gitkb/meta_plugin_protocol.git
+          git clone --depth 1 https://github.com/gitkb/meta_cli.git
+          git clone --depth 1 https://github.com/gitkb/meta_core.git
+          git clone --depth 1 https://github.com/gitkb/meta_git_lib.git
+          git clone --depth 1 https://github.com/gitkb/loop_lib.git
 
       - name: Create workspace Cargo.toml
         run: |
@@ -89,7 +89,7 @@ jobs:
           version = "0.1.0"
           edition = "2021"
           license = "MIT"
-          repository = "https://github.com/harmony-labs/meta"
+          repository = "https://github.com/gitkb/meta"
           EOF
 
       - name: Install Rust toolchain
@@ -117,11 +117,11 @@ jobs:
 
       - name: Clone dependencies
         run: |
-          git clone --depth 1 https://github.com/harmony-labs/meta_plugin_protocol.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_cli.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_core.git
-          git clone --depth 1 https://github.com/harmony-labs/meta_git_lib.git
-          git clone --depth 1 https://github.com/harmony-labs/loop_lib.git
+          git clone --depth 1 https://github.com/gitkb/meta_plugin_protocol.git
+          git clone --depth 1 https://github.com/gitkb/meta_cli.git
+          git clone --depth 1 https://github.com/gitkb/meta_core.git
+          git clone --depth 1 https://github.com/gitkb/meta_git_lib.git
+          git clone --depth 1 https://github.com/gitkb/loop_lib.git
 
       - name: Create workspace Cargo.toml
         run: |
@@ -134,7 +134,7 @@ jobs:
           version = "0.1.0"
           edition = "2021"
           license = "MIT"
-          repository = "https://github.com/harmony-labs/meta"
+          repository = "https://github.com/gitkb/meta"
           EOF
 
       - name: Install Rust toolchain

--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Notify parent repo
         # PARENT_REPO_PAT requires `repo` scope (or fine-grained `contents:write`)
-        # on harmony-labs/meta. Configure in Settings → Secrets → Actions.
+        # on gitkb/meta. Configure in Settings → Secrets → Actions.
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.PARENT_REPO_PAT }}
-          repository: harmony-labs/meta
+          repository: gitkb/meta
           event-type: child-repo-updated
           client-payload: >-
             {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,8 @@ pub fn execute_command(
     provided_projects: &[String],
     cwd: &Path,
 ) -> CommandResult {
-    // Intercept --help/-h before dispatching to subcommand handlers
-    if args.iter().any(|a| a == "--help" || a == "-h") {
-        return CommandResult::ShowHelp(None);
+    if has_help_token(command, args) {
+        return project_command_help(command);
     }
 
     // project dependents reads the dependency graph directly
@@ -126,6 +125,100 @@ pub fn execute_command(
             "unrecognized command '{command}'. Use 'meta git update' to sync projects."
         ))),
     }
+}
+
+fn has_help_token(command: &str, args: &[String]) -> bool {
+    command
+        .split_whitespace()
+        .chain(args.iter().map(String::as_str))
+        .any(|arg| arg == "--help" || arg == "-h")
+}
+
+fn project_command_help(command: &str) -> CommandResult {
+    let words: Vec<&str> = command
+        .split_whitespace()
+        .filter(|word| *word != "--help" && *word != "-h")
+        .collect();
+    let subcommand = words.get(1).copied();
+
+    let help = match subcommand {
+        Some("list") | Some("ls") => {
+            r#"meta project list - Inspect the meta repo graph
+
+Usage: meta project list [OPTIONS]
+
+Options:
+  --json          Emit a structured tree with root, cwd, project paths, repo URLs, tags, and nested projects
+  --recursive    Include projects from nested meta repos
+  --depth <N>    Limit recursive traversal depth
+
+Agent hints:
+  Use `meta project list --recursive --json` before broad changes to discover the full repo graph.
+  Use non-recursive output for a quick human-readable view of the current meta repo.
+
+Examples:
+  meta project list
+  meta project list --recursive
+  meta project list --recursive --json"#
+        }
+        Some("check") => {
+            r#"meta project check - Verify configured projects are present
+
+Usage: meta project check [OPTIONS]
+
+Options:
+  --recursive    Check nested meta repos as well
+  --depth <N>    Limit recursive traversal depth
+
+Agent hints:
+  Run this when commands fail because a child checkout is missing.
+  Missing repos can usually be cloned with `meta git update`.
+
+Examples:
+  meta project check
+  meta project check --recursive"#
+        }
+        Some("dependents") => {
+            r#"meta project dependents - Find projects that depend on another project
+
+Usage: meta project dependents <PROJECT> [OPTIONS]
+
+Arguments:
+  <PROJECT>      Project name or provided capability to search for
+
+Options:
+  --json         Emit machine-readable dependent project records
+
+Agent hints:
+  Use this before changing shared libraries or APIs to identify likely blast radius.
+  Pair with `meta project list --recursive --json` when working across nested meta repos.
+
+Examples:
+  meta project dependents meta_core
+  meta project dependents auth --json"#
+        }
+        _ => {
+            r#"meta project - Inspect and validate meta workspace projects
+
+Usage: meta project <COMMAND>
+
+Commands:
+  list          List projects defined in .meta (alias: ls)
+  check         Verify configured projects are cloned
+  dependents    List projects that depend on a project or capability
+
+Agent hints:
+  Prefer `meta project list --recursive --json` for codebase discovery.
+  Use `meta project check --recursive` before assuming a repo is intentionally absent.
+
+Examples:
+  meta project list --recursive --json
+  meta project check
+  meta project dependents meta_core"#
+        }
+    };
+
+    CommandResult::Message(help.to_string())
 }
 
 /// Execute a project command recursively across provided project directories


### PR DESCRIPTION
## Summary
- add explicit command help for `project list`, `project check`, and `project dependents`
- include agent-oriented scope and next-step guidance
- keep help side-effect free

## Verification
- cargo fmt --all
- cargo test -q --workspace
- cargo build --workspace --quiet
- bats tests/help.bats

Implements [[tasks/harmony-677]]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved help text for `meta project` subcommands, including detailed usage guidance, options, and examples for `list`, `check`, and `dependents` operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gitkb/meta_project_cli/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->